### PR TITLE
Fix installation of new pulseaudio metapackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-About pulseaudio-split-feedstock
-================================
+About pulseaudio-feedstock
+==========================
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pulseaudio-feedstock/blob/main/LICENSE.txt)
 
-About pulseaudio-split
-----------------------
+About pulseaudio
+----------------
 
 Home: https://www.freedesktop.org/wiki/Software/PulseAudio/
 
@@ -89,10 +89,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pulseaudio--client-green.svg)](https://anaconda.org/conda-forge/pulseaudio-client) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pulseaudio-client.svg)](https://anaconda.org/conda-forge/pulseaudio-client) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pulseaudio-client.svg)](https://anaconda.org/conda-forge/pulseaudio-client) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pulseaudio-client.svg)](https://anaconda.org/conda-forge/pulseaudio-client) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pulseaudio--daemon-green.svg)](https://anaconda.org/conda-forge/pulseaudio-daemon) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pulseaudio-daemon.svg)](https://anaconda.org/conda-forge/pulseaudio-daemon) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pulseaudio-daemon.svg)](https://anaconda.org/conda-forge/pulseaudio-daemon) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pulseaudio-daemon.svg)](https://anaconda.org/conda-forge/pulseaudio-daemon) |
 
-Installing pulseaudio-split
-===========================
+Installing pulseaudio
+=====================
 
-Installing `pulseaudio-split` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `pulseaudio` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
@@ -178,17 +178,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating pulseaudio-split-feedstock
-===================================
+Updating pulseaudio-feedstock
+=============================
 
-If you would like to improve the pulseaudio-split recipe or build a new
+If you would like to improve the pulseaudio recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/pulseaudio-split-feedstock are
+Note that all branches in the conda-forge/pulseaudio-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -159,6 +159,7 @@ about:
   doc_url: https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/
 
 extra:
+  feedstock-name: pulseaudio
   recipe-maintainers:
     - andfoy
     - ryanvolz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ outputs:
         - libsystemd
         - zlib
       run_constrained:
-        - {{ pin_subpackage('pulseaudio', exact=True) }}
+        - pulseaudio {{ version }} *_{{ PKG_BUILD }}
     test:
       commands:
         - test -f ${PREFIX}/include/pulse/version.h
@@ -109,7 +109,7 @@ outputs:
         - {{ pin_compatible('libtool', max_pin='x') }}
         - {{ pin_subpackage('pulseaudio-client', exact=True) }}
       run_constrained:
-        - {{ pin_subpackage('pulseaudio', exact=True) }}
+        - pulseaudio {{ version }} *_{{ PKG_BUILD }}
     test:
       requires:
         - pkg-config

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,25 +16,6 @@ build:
   skip: true  # [not linux]
 
 outputs:
-  - name: pulseaudio
-    build:
-      run_exports:
-        - {{ pin_subpackage('pulseaudio-client', max_pin='x.x') }}
-      ignore_run_exports_from:
-        - {{ compiler('cxx') }}
-    requirements:
-      build:
-        # Add these so the build string gets generated correctly
-        - {{ compiler('c') }}
-        - {{ compiler('cxx') }}
-      run:
-        - {{ pin_subpackage('pulseaudio-client', exact=True) }}
-        - {{ pin_subpackage('pulseaudio-daemon', exact=True) }}
-    test:
-      commands:
-        - pactl --help
-        - pulseaudio --help
-
   - name: pulseaudio-client
     script: build-client.sh
     build:
@@ -149,6 +130,24 @@ outputs:
       license_file: GPL
       summary: A networked sound server
       doc_url: https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/
+  - name: pulseaudio
+    build:
+      run_exports:
+        - {{ pin_subpackage('pulseaudio-client', max_pin='x.x') }}
+      ignore_run_exports_from:
+        - {{ compiler('cxx') }}
+    requirements:
+      build:
+        # Add these so the build string gets generated correctly
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+      run:
+        - {{ pin_subpackage('pulseaudio-client', exact=True) }}
+        - {{ pin_subpackage('pulseaudio-daemon', exact=True) }}
+    test:
+      commands:
+        - pactl --help
+        - pulseaudio --help
 
 about:
   home: https://www.freedesktop.org/wiki/Software/PulseAudio/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "16.1" %}
+{% set build = "3" %}
 
 package:
   name: pulseaudio-split
@@ -12,7 +13,7 @@ source:
     - 0002-tests-Skip-tests-that-fail-for-release-build-when-pa.patch
 
 build:
-  number: 3
+  number: {{ build }}
   skip: true  # [not linux]
 
 outputs:
@@ -46,7 +47,7 @@ outputs:
         - libsystemd
         - zlib
       run_constrained:
-        - pulseaudio {{ version }} *_{{ PKG_BUILD }}
+        - pulseaudio {{ version }} *_{{ build }}
     test:
       commands:
         - test -f ${PREFIX}/include/pulse/version.h
@@ -109,7 +110,7 @@ outputs:
         - {{ pin_compatible('libtool', max_pin='x') }}
         - {{ pin_subpackage('pulseaudio-client', exact=True) }}
       run_constrained:
-        - pulseaudio {{ version }} *_{{ PKG_BUILD }}
+        - pulseaudio {{ version }} *_{{ build }}
     test:
       requires:
         - pkg-config

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0002-tests-Skip-tests-that-fail-for-release-build-when-pa.patch
 
 build:
-  number: 2
+  number: 3
   skip: true  # [not linux]
 
 outputs:
@@ -20,6 +20,8 @@ outputs:
     build:
       run_exports:
         - {{ pin_subpackage('pulseaudio-client', max_pin='x.x') }}
+      ignore_run_exports_from:
+        - {{ compiler('cxx') }}
     requirements:
       build:
         # Add these so the build string gets generated correctly
@@ -28,6 +30,10 @@ outputs:
       run:
         - {{ pin_subpackage('pulseaudio-client', exact=True) }}
         - {{ pin_subpackage('pulseaudio-daemon', exact=True) }}
+    test:
+      commands:
+        - pactl --help
+        - pulseaudio --help
 
   - name: pulseaudio-client
     script: build-client.sh
@@ -35,6 +41,7 @@ outputs:
       run_exports:
         - {{ pin_subpackage('pulseaudio-client', max_pin='x.x') }}
       ignore_run_exports_from:
+        - {{ compiler('cxx') }}
         - zlib
     requirements:
       build:
@@ -80,6 +87,7 @@ outputs:
       run_exports:
         - {{ pin_subpackage('pulseaudio-daemon', max_pin='x.x') }}
       ignore_run_exports_from:
+        - {{ compiler('cxx') }}
         - zlib
     requirements:
       build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Installation of the new `pulseaudio` metapackage fails after #32 because the `run_constrained` of both `pulseaudio-client` and `pulseaudio-daemon` require only the build number and miss the rest of the build string. This wasn't tested since the metapackage had no tests to run.